### PR TITLE
fixed name conflict error for cluster_config

### DIFF
--- a/osbenchmark/builder/builder.py
+++ b/osbenchmark/builder/builder.py
@@ -612,18 +612,18 @@ class NodeBuilderActor(actor.BenchmarkActor):
 def load_cluster_config(cfg, external):
     # externally provisioned clusters do not support cluster_configs / plugins
     if external:
-        cluster_config = None
+        cluster_configuration = None
         plugins = []
     else:
         cluster_config_path = cluster_config.cluster_config_path(cfg)
-        cluster_config = cluster_config.load_cluster_config(
+        cluster_configuration = cluster_config.load_cluster_config(
             cluster_config_path,
             cfg.opts("builder", "cluster_config.names"),
             cfg.opts("builder", "cluster_config.params"))
         plugins = cluster_config.load_plugins(cluster_config_path,
                                     cfg.opts("builder", "cluster_config.plugins", mandatory=False),
                                     cfg.opts("builder", "plugin.params", mandatory=False))
-    return cluster_config, plugins
+    return cluster_configuration, plugins
 
 
 def create(cfg, metrics_store, node_ip, node_http_port, all_node_ips, all_node_ids, sources=False, distribution=False,


### PR DESCRIPTION
### Description
[Describe what this change achieves]
- fixed name resolution error for cluster_config variable as it was used as a local variable and also as module

### Issues Resolved
[List any issues this PR will resolve]
NA

### Testing
Before fix
```
python3 osbenchmark/benchmark.py install --cluster-config=defaults --distribution-version=2.10.0 --node-name="osb-node-3" --network-host="127.0.0.1" --http-port=9200 --master-nodes="osb-node-3" --seed-hosts="127.0.0.1:9300"

[ERROR] Cannot install. local variable 'cluster_config' referenced before assignment.

Getting further help:
*********************
* Check the log files in /Users/chinmay/.benchmark/logs for errors.
* Read the documentation at https://opensearch.org/docs.
* Ask a question on the forum at https://forum.opensearch.org/.
* Raise an issue at https://github.com/opensearch-project/OpenSearch-Benchmark/issues and include the log files in /Users/chinmay/.benchmark/logs.

-------------------------------
[INFO] FAILURE (took 0 seconds)
-------------------------------
```

After fix
```
python3 osbenchmark/benchmark.py install --cluster-config=defaults --distribution-version=2.10.0 --node-name="osb-node-3" --network-host="127.0.0.1" --http-port=9200 --master-nodes="osb-node-3" --seed-hosts="127.0.0.1:9300"

{
  "installation-id": "3d626090-b216-46f7-9ef6-5173b90965f3"
}

-------------------------------
[INFO] SUCCESS (took 3 seconds)
-------------------------------
```
[Describe how this change was tested]

---
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
